### PR TITLE
Add animated screen container

### DIFF
--- a/homesync-india/src/components/animations/FadeInView.tsx
+++ b/homesync-india/src/components/animations/FadeInView.tsx
@@ -1,0 +1,35 @@
+import React, { useEffect } from "react";
+import Animated, {
+  useSharedValue,
+  withTiming,
+  useAnimatedStyle,
+} from "react-native-reanimated";
+import { ViewStyle } from "react-native";
+
+interface FadeInViewProps {
+  duration?: number;
+  style?: ViewStyle;
+  children: React.ReactNode;
+}
+
+const FadeInView: React.FC<FadeInViewProps> = ({
+  duration = 500,
+  style,
+  children,
+}) => {
+  const opacity = useSharedValue(0);
+
+  useEffect(() => {
+    opacity.value = withTiming(1, { duration });
+  }, [duration, opacity]);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    opacity: opacity.value,
+  }));
+
+  return (
+    <Animated.View style={[style, animatedStyle]}>{children}</Animated.View>
+  );
+};
+
+export default FadeInView;

--- a/homesync-india/src/components/animations/ScreenContainer.tsx
+++ b/homesync-india/src/components/animations/ScreenContainer.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { ViewStyle } from "react-native";
+import FadeInView from "./FadeInView";
+
+interface ScreenContainerProps {
+  duration?: number;
+  style?: ViewStyle;
+  children: React.ReactNode;
+}
+
+const ScreenContainer: React.FC<ScreenContainerProps> = ({
+  duration,
+  style,
+  children,
+}) => {
+  return (
+    <SafeAreaView style={{ flex: 1 }}>
+      <FadeInView duration={duration} style={[{ flex: 1 }, style]}>
+        {children}
+      </FadeInView>
+    </SafeAreaView>
+  );
+};
+
+export default ScreenContainer;

--- a/homesync-india/src/screens/AdminScreen.tsx
+++ b/homesync-india/src/screens/AdminScreen.tsx
@@ -1,8 +1,22 @@
-import React, { useState, useCallback } from 'react';
-import { ScrollView, StyleSheet, View, TouchableOpacity, RefreshControl, Dimensions } from 'react-native';
-import { Text, useTheme, Card, IconButton, Button, ActivityIndicator } from 'react-native-paper';
-import { SafeAreaView } from 'react-native-safe-area-context';
-import { useNavigation } from '@react-navigation/native';
+import React, { useState, useCallback } from "react";
+import {
+  ScrollView,
+  StyleSheet,
+  View,
+  TouchableOpacity,
+  RefreshControl,
+  Dimensions,
+} from "react-native";
+import {
+  Text,
+  useTheme,
+  Card,
+  IconButton,
+  Button,
+  ActivityIndicator,
+} from "react-native-paper";
+import ScreenContainer from "../components/animations/ScreenContainer";
+import { useNavigation } from "@react-navigation/native";
 
 type Screen = {
   name: string;
@@ -15,7 +29,7 @@ type ModuleSection = {
   screens: Screen[];
 };
 
-const { width: screenWidth } = Dimensions.get('window');
+const { width: screenWidth } = Dimensions.get("window");
 
 const AdminScreen: React.FC = () => {
   const theme = useTheme();
@@ -24,11 +38,11 @@ const AdminScreen: React.FC = () => {
 
   // Statistics data
   const stats = [
-    { label: 'Staff Members', value: '4' },
-    { label: 'Bills Due', value: '7' },
-    { label: "Today's Events", value: '3' },
+    { label: "Staff Members", value: "4" },
+    { label: "Bills Due", value: "7" },
+    { label: "Today's Events", value: "3" },
   ];
-  
+
   // Handle refresh
   const onRefresh = useCallback(() => {
     setRefreshing(true);
@@ -42,38 +56,38 @@ const AdminScreen: React.FC = () => {
   // Module sections data
   const sections: ModuleSection[] = [
     {
-      title: 'Home Management',
+      title: "Home Management",
       screens: [
-        { name: 'Staff', route: 'Staff', icon: 'account-group' },
-        { name: 'Bills', route: 'Bills', icon: 'file-document' },
-        { name: 'Grocery', route: 'Grocery', icon: 'cart' },
-        { name: 'Calendar', route: 'Calendar', icon: 'calendar' },
+        { name: "Staff", route: "Staff", icon: "account-group" },
+        { name: "Bills", route: "Bills", icon: "file-document" },
+        { name: "Grocery", route: "Grocery", icon: "cart" },
+        { name: "Calendar", route: "Calendar", icon: "calendar" },
       ],
     },
     {
-      title: 'Family & Finance',
+      title: "Family & Finance",
       screens: [
-        { name: 'Vehicle', route: 'Vehicle', icon: 'car' },
-        { name: 'Finance', route: 'FinanceOverview', icon: 'currency-inr' },
-        { name: 'Family', route: 'FamilyList', icon: 'account-multiple' },
-        { name: 'Documents', route: 'DocumentList', icon: 'folder' },
+        { name: "Vehicle", route: "Vehicle", icon: "car" },
+        { name: "Finance", route: "FinanceOverview", icon: "currency-inr" },
+        { name: "Family", route: "FamilyList", icon: "account-multiple" },
+        { name: "Documents", route: "DocumentList", icon: "folder" },
       ],
     },
     {
-      title: 'Health & Services',
+      title: "Health & Services",
       screens: [
-        { name: 'Health', route: 'HealthDashboard', icon: 'heart-pulse' },
-        { name: 'Analytics', route: 'Analytics', icon: 'chart-bar' },
-        { name: 'Chat', route: 'Chat', icon: 'message' },
-        { name: 'Settings', route: 'AISettings', icon: 'cog' },
+        { name: "Health", route: "HealthDashboard", icon: "heart-pulse" },
+        { name: "Analytics", route: "Analytics", icon: "chart-bar" },
+        { name: "Chat", route: "Chat", icon: "message" },
+        { name: "Settings", route: "AISettings", icon: "cog" },
       ],
     },
   ];
-  
+
   const navigateTo = (routeName: string) => {
     navigation.navigate(routeName);
   };
-  
+
   // Define screen preview type
   type ScreenPreview = {
     title: string;
@@ -81,7 +95,7 @@ const AdminScreen: React.FC = () => {
     route: string;
     description: string;
   };
-  
+
   // Get the available routes from the navigation state
   const getAvailableScreens = () => {
     const state = navigation.getState();
@@ -90,30 +104,90 @@ const AdminScreen: React.FC = () => {
 
   // All possible screens for the carousel
   const allScreenPreviews: ScreenPreview[] = [
-    { title: 'Home', icon: 'home', route: 'Home', description: 'Landing page with login options' },
-    { title: 'Staff', icon: 'account-group', route: 'Staff', description: 'Manage household staff' },
-    { title: 'Bills', icon: 'file-document', route: 'Bills', description: 'Track and pay bills' },
-    { title: 'Grocery', icon: 'cart', route: 'Grocery', description: 'Shopping lists and inventory' },
-    { title: 'Calendar', icon: 'calendar', route: 'Calendar', description: 'Events and reminders' },
-    { title: 'Health', icon: 'heart-pulse', route: 'HealthDashboard', description: 'Family health records' },
-    { title: 'Finance', icon: 'currency-inr', route: 'FinanceOverview', description: 'Budget and expenses' },
-    { title: 'Family', icon: 'account-group', route: 'FamilyList', description: 'Family members management' },
-    { title: 'Documents', icon: 'file-document', route: 'DocumentList', description: 'Important documents' },
-    { title: 'Settings', icon: 'cog', route: 'Settings', description: 'App preferences' },
-    { title: 'Analytics', icon: 'chart-bar', route: 'Analytics', description: 'Household insights' },
-    { title: 'Login', icon: 'login', route: 'Login', description: 'User authentication' },
+    {
+      title: "Home",
+      icon: "home",
+      route: "Home",
+      description: "Landing page with login options",
+    },
+    {
+      title: "Staff",
+      icon: "account-group",
+      route: "Staff",
+      description: "Manage household staff",
+    },
+    {
+      title: "Bills",
+      icon: "file-document",
+      route: "Bills",
+      description: "Track and pay bills",
+    },
+    {
+      title: "Grocery",
+      icon: "cart",
+      route: "Grocery",
+      description: "Shopping lists and inventory",
+    },
+    {
+      title: "Calendar",
+      icon: "calendar",
+      route: "Calendar",
+      description: "Events and reminders",
+    },
+    {
+      title: "Health",
+      icon: "heart-pulse",
+      route: "HealthDashboard",
+      description: "Family health records",
+    },
+    {
+      title: "Finance",
+      icon: "currency-inr",
+      route: "FinanceOverview",
+      description: "Budget and expenses",
+    },
+    {
+      title: "Family",
+      icon: "account-group",
+      route: "FamilyList",
+      description: "Family members management",
+    },
+    {
+      title: "Documents",
+      icon: "file-document",
+      route: "DocumentList",
+      description: "Important documents",
+    },
+    {
+      title: "Settings",
+      icon: "cog",
+      route: "Settings",
+      description: "App preferences",
+    },
+    {
+      title: "Analytics",
+      icon: "chart-bar",
+      route: "Analytics",
+      description: "Household insights",
+    },
+    {
+      title: "Login",
+      icon: "login",
+      route: "Login",
+      description: "User authentication",
+    },
   ];
-  
+
   // Filter to only available screens
   const availableRoutes = getAvailableScreens();
-  const screenPreviews: ScreenPreview[] = allScreenPreviews.filter(screen => 
-    availableRoutes.includes(screen.route)
+  const screenPreviews: ScreenPreview[] = allScreenPreviews.filter((screen) =>
+    availableRoutes.includes(screen.route),
   );
-  
+
   // No carousel render item needed with simple ScrollView
 
   return (
-    <SafeAreaView style={styles.container}>
+    <ScreenContainer style={styles.container}>
       <ScrollView
         contentContainerStyle={styles.scrollContent}
         showsVerticalScrollIndicator={false}
@@ -127,26 +201,36 @@ const AdminScreen: React.FC = () => {
         }
       >
         <View style={styles.headerContainer}>
-          <Text variant="headlineLarge" style={styles.title}>Admin Dashboard</Text>
-          <Text variant="bodyMedium" style={styles.subtitle}>HomeSync India Management Console</Text>
+          <Text variant="headlineLarge" style={styles.title}>
+            Admin Dashboard
+          </Text>
+          <Text variant="bodyMedium" style={styles.subtitle}>
+            HomeSync India Management Console
+          </Text>
         </View>
-        
+
         {/* Quick Stats Section */}
         <View style={styles.statsContainer}>
           {stats.map((stat, index) => (
             <Card key={index} style={styles.statCard}>
               <Card.Content style={styles.statContent}>
-                <Text variant="headlineMedium" style={styles.statValue}>{stat.value}</Text>
-                <Text variant="bodySmall" style={styles.statLabel}>{stat.label}</Text>
+                <Text variant="headlineMedium" style={styles.statValue}>
+                  {stat.value}
+                </Text>
+                <Text variant="bodySmall" style={styles.statLabel}>
+                  {stat.label}
+                </Text>
               </Card.Content>
             </Card>
           ))}
         </View>
-        
+
         {/* Module Sections */}
         {sections.map((section, sectionIndex) => (
           <View key={sectionIndex} style={styles.sectionContainer}>
-            <Text variant="titleMedium" style={styles.sectionTitle}>{section.title}</Text>
+            <Text variant="titleMedium" style={styles.sectionTitle}>
+              {section.title}
+            </Text>
             <View style={styles.moduleGrid}>
               {section.screens.map((screen, screenIndex) => (
                 <TouchableOpacity
@@ -162,7 +246,9 @@ const AdminScreen: React.FC = () => {
                         iconColor={theme.colors.primary}
                         style={styles.moduleIcon}
                       />
-                      <Text variant="bodyMedium" style={styles.moduleTitle}>{screen.name}</Text>
+                      <Text variant="bodyMedium" style={styles.moduleTitle}>
+                        {screen.name}
+                      </Text>
                     </Card.Content>
                   </Card>
                 </TouchableOpacity>
@@ -170,32 +256,46 @@ const AdminScreen: React.FC = () => {
             </View>
           </View>
         ))}
-        
+
         {/* Recent Notifications Preview */}
         <View style={styles.notificationsSection}>
           <View style={styles.notificationsHeader}>
-            <Text variant="titleMedium" style={styles.sectionTitle}>Recent Notifications</Text>
-            <Button mode="text" onPress={() => {}}>View All</Button>
+            <Text variant="titleMedium" style={styles.sectionTitle}>
+              Recent Notifications
+            </Text>
+            <Button mode="text" onPress={() => {}}>
+              View All
+            </Button>
           </View>
           <Card style={styles.notificationCard}>
             <Card.Content>
-              <Text variant="bodyMedium">Staff attendance updated for Ramesh</Text>
-              <Text variant="bodySmall" style={styles.notificationTime}>2 hours ago</Text>
+              <Text variant="bodyMedium">
+                Staff attendance updated for Ramesh
+              </Text>
+              <Text variant="bodySmall" style={styles.notificationTime}>
+                2 hours ago
+              </Text>
             </Card.Content>
           </Card>
           <Card style={styles.notificationCard}>
             <Card.Content>
               <Text variant="bodyMedium">Electricity bill due tomorrow</Text>
-              <Text variant="bodySmall" style={styles.notificationTime}>5 hours ago</Text>
+              <Text variant="bodySmall" style={styles.notificationTime}>
+                5 hours ago
+              </Text>
             </Card.Content>
           </Card>
         </View>
-        
+
         {/* Screen Carousel */}
         <View style={styles.carouselSection}>
-          <Text variant="titleMedium" style={styles.sectionTitle}>Available Screens</Text>
-          <Text variant="bodySmall" style={styles.carouselSubtitle}>Swipe to preview and navigate</Text>
-          
+          <Text variant="titleMedium" style={styles.sectionTitle}>
+            Available Screens
+          </Text>
+          <Text variant="bodySmall" style={styles.carouselSubtitle}>
+            Swipe to preview and navigate
+          </Text>
+
           <ScrollView
             horizontal
             showsHorizontalScrollIndicator={false}
@@ -212,10 +312,17 @@ const AdminScreen: React.FC = () => {
                       size={40}
                       iconColor={theme.colors.primary}
                     />
-                    <Text variant="titleMedium" style={styles.carouselTitle}>{item.title}</Text>
-                    <Text variant="bodySmall" style={styles.carouselDescription}>{item.description}</Text>
-                    <Button 
-                      mode="contained" 
+                    <Text variant="titleMedium" style={styles.carouselTitle}>
+                      {item.title}
+                    </Text>
+                    <Text
+                      variant="bodySmall"
+                      style={styles.carouselDescription}
+                    >
+                      {item.description}
+                    </Text>
+                    <Button
+                      mode="contained"
                       style={styles.carouselButton}
                       onPress={() => navigation.navigate(item.route)}
                     >
@@ -227,17 +334,17 @@ const AdminScreen: React.FC = () => {
             ))}
           </ScrollView>
         </View>
-        
+
         <View style={styles.spacer} />
       </ScrollView>
-    </SafeAreaView>
+    </ScreenContainer>
   );
 };
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#f8f9fa',
+    backgroundColor: "#f8f9fa",
   },
   scrollContent: {
     padding: 16,
@@ -246,18 +353,18 @@ const styles = StyleSheet.create({
     marginBottom: 24,
   },
   title: {
-    fontWeight: 'bold',
+    fontWeight: "bold",
     marginBottom: 4,
-    color: '#333',
-    flexWrap: 'wrap',
+    color: "#333",
+    flexWrap: "wrap",
   },
   subtitle: {
-    color: '#666',
-    flexWrap: 'wrap',
+    color: "#666",
+    flexWrap: "wrap",
   },
   statsContainer: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
+    flexDirection: "row",
+    justifyContent: "space-between",
     marginBottom: 24,
   },
   statCard: {
@@ -266,34 +373,34 @@ const styles = StyleSheet.create({
     elevation: 2,
   },
   statContent: {
-    alignItems: 'center',
+    alignItems: "center",
     padding: 8,
   },
   statValue: {
-    fontWeight: 'bold',
-    color: '#333',
+    fontWeight: "bold",
+    color: "#333",
   },
   statLabel: {
-    color: '#666',
-    textAlign: 'center',
-    flexWrap: 'wrap',
+    color: "#666",
+    textAlign: "center",
+    flexWrap: "wrap",
   },
   sectionContainer: {
     marginBottom: 24,
   },
   sectionTitle: {
     marginBottom: 12,
-    color: '#333',
-    fontWeight: '600',
+    color: "#333",
+    fontWeight: "600",
   },
   moduleGrid: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    justifyContent: 'space-between',
+    flexDirection: "row",
+    flexWrap: "wrap",
+    justifyContent: "space-between",
     marginHorizontal: -4,
   },
   moduleCard: {
-    width: '25%',
+    width: "25%",
     paddingHorizontal: 4,
     marginBottom: 16,
   },
@@ -302,18 +409,18 @@ const styles = StyleSheet.create({
     height: 96,
   },
   moduleCardContent: {
-    alignItems: 'center',
-    justifyContent: 'center',
+    alignItems: "center",
+    justifyContent: "center",
     padding: 8,
-    height: '100%',
+    height: "100%",
   },
   moduleIcon: {
     margin: 0,
     padding: 0,
   },
   moduleTitle: {
-    textAlign: 'center',
-    flexWrap: 'wrap',
+    textAlign: "center",
+    flexWrap: "wrap",
     fontSize: 12,
     marginTop: 4,
   },
@@ -321,9 +428,9 @@ const styles = StyleSheet.create({
     marginBottom: 24,
   },
   notificationsHeader: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
     marginBottom: 8,
   },
   notificationCard: {
@@ -331,7 +438,7 @@ const styles = StyleSheet.create({
     elevation: 2,
   },
   notificationTime: {
-    color: '#999',
+    color: "#999",
     marginTop: 4,
   },
   spacer: {
@@ -348,9 +455,9 @@ const styles = StyleSheet.create({
     paddingHorizontal: 8,
   },
   carouselSubtitle: {
-    color: '#666',
+    color: "#666",
     marginBottom: 16,
-    textAlign: 'center',
+    textAlign: "center",
   },
   carouselCard: {
     elevation: 4,
@@ -358,20 +465,20 @@ const styles = StyleSheet.create({
     height: 220,
   },
   carouselCardContent: {
-    alignItems: 'center',
-    justifyContent: 'center',
-    height: '100%',
+    alignItems: "center",
+    justifyContent: "center",
+    height: "100%",
     padding: 16,
   },
   carouselTitle: {
-    fontWeight: 'bold',
+    fontWeight: "bold",
     marginVertical: 8,
-    textAlign: 'center',
+    textAlign: "center",
   },
   carouselDescription: {
-    textAlign: 'center',
+    textAlign: "center",
     marginBottom: 16,
-    color: '#666',
+    color: "#666",
   },
   carouselButton: {
     marginTop: 8,

--- a/homesync-india/src/screens/ChatScreen.tsx
+++ b/homesync-india/src/screens/ChatScreen.tsx
@@ -1,99 +1,99 @@
-import React, { useState, useRef } from 'react';
-import { 
-  View, 
-  Text, 
-  SafeAreaView,
+import React, { useState, useRef } from "react";
+import {
+  View,
+  Text,
   TextInput,
   FlatList,
   KeyboardAvoidingView,
   Platform,
   TouchableOpacity,
-  ActivityIndicator
-} from 'react-native';
-import { Ionicons } from '@expo/vector-icons';
-import aiService from '../services/ai/AIService';
-import { AIMessage } from '../services/api/types';
+  ActivityIndicator,
+} from "react-native";
+import ScreenContainer from "../components/animations/ScreenContainer";
+import { Ionicons } from "@expo/vector-icons";
+import aiService from "../services/ai/AIService";
+import { AIMessage } from "../services/api/types";
 
 const ChatScreen = () => {
   const [messages, setMessages] = useState<AIMessage[]>([
-    { 
-      role: 'assistant', 
-      content: 'Hello! I am your HomeSync assistant. How can I help manage your household today?' 
-    }
+    {
+      role: "assistant",
+      content:
+        "Hello! I am your HomeSync assistant. How can I help manage your household today?",
+    },
   ]);
-  const [input, setInput] = useState('');
+  const [input, setInput] = useState("");
   const [loading, setLoading] = useState(false);
-  
+
   const flatListRef = useRef<FlatList>(null);
 
   const sendMessage = async () => {
     if (!input.trim() || loading) return;
-    
+
     const userMessage: AIMessage = {
-      role: 'user',
-      content: input.trim()
+      role: "user",
+      content: input.trim(),
     };
-    
+
     // Update UI with user message immediately
-    setMessages(prevMessages => [...prevMessages, userMessage]);
-    setInput('');
+    setMessages((prevMessages) => [...prevMessages, userMessage]);
+    setInput("");
     setLoading(true);
-    
+
     try {
       // Call AI service
       const response = await aiService.generateCompletion({
         messages: [...messages, userMessage],
-        provider: aiService.getProvider()
+        provider: aiService.getProvider(),
       });
-      
+
       if (response.data) {
         // Add AI response to messages
         const aiMessage: AIMessage = {
-          role: 'assistant',
-          content: response.data.content
+          role: "assistant",
+          content: response.data.content,
         };
-        setMessages(prevMessages => [...prevMessages, aiMessage]);
+        setMessages((prevMessages) => [...prevMessages, aiMessage]);
       } else if (response.error) {
         // Show error message
         const errorMessage: AIMessage = {
-          role: 'assistant',
-          content: `Sorry, I encountered an error: ${response.error}`
+          role: "assistant",
+          content: `Sorry, I encountered an error: ${response.error}`,
         };
-        setMessages(prevMessages => [...prevMessages, errorMessage]);
+        setMessages((prevMessages) => [...prevMessages, errorMessage]);
       }
     } catch (error) {
-      console.error('AI service error:', error);
+      console.error("AI service error:", error);
       // Show generic error message
       const errorMessage: AIMessage = {
-        role: 'assistant',
-        content: 'Sorry, I encountered an unexpected error. Please try again later.'
+        role: "assistant",
+        content:
+          "Sorry, I encountered an unexpected error. Please try again later.",
       };
-      setMessages(prevMessages => [...prevMessages, errorMessage]);
+      setMessages((prevMessages) => [...prevMessages, errorMessage]);
     } finally {
       setLoading(false);
-      
+
       // Scroll to bottom after a short delay to ensure the new message is rendered
       setTimeout(() => {
         flatListRef.current?.scrollToEnd({ animated: true });
       }, 100);
     }
   };
-  
+
   // Render individual message
   const renderMessage = ({ item }: { item: AIMessage }) => {
-    const isUser = item.role === 'user';
-    
+    const isUser = item.role === "user";
+
     return (
-      <View 
+      <View
         className={`px-4 py-3 rounded-lg max-w-[80%] mb-3 ${
-          isUser 
-            ? 'bg-primary-500 self-end rounded-tr-none' 
-            : 'bg-gray-200 self-start rounded-tl-none'
+          isUser
+            ? "bg-primary-500 self-end rounded-tr-none"
+            : "bg-gray-200 self-start rounded-tl-none"
         }`}
       >
-        <Text 
-          className={`${isUser ? 'text-white' : 'text-gray-800'}`}
-        >
+        <Text className={`${isUser ? "text-white" : "text-gray-800"}`}>
           {item.content}
         </Text>
       </View>
@@ -101,11 +101,11 @@ const ChatScreen = () => {
   };
 
   return (
-    <SafeAreaView className="flex-1 bg-gray-100">
+    <ScreenContainer style={{ backgroundColor: "#f3f4f6" }}>
       <KeyboardAvoidingView
         className="flex-1"
-        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
-        keyboardVerticalOffset={Platform.OS === 'ios' ? 90 : 0}
+        behavior={Platform.OS === "ios" ? "padding" : undefined}
+        keyboardVerticalOffset={Platform.OS === "ios" ? 90 : 0}
       >
         {/* Messages */}
         <FlatList
@@ -116,7 +116,7 @@ const ChatScreen = () => {
           contentContainerClassName="p-4"
           onLayout={() => flatListRef.current?.scrollToEnd({ animated: false })}
         />
-        
+
         {/* Input area */}
         <View className="border-t border-gray-200 p-2 bg-white flex-row items-center">
           <TextInput
@@ -127,12 +127,12 @@ const ChatScreen = () => {
             multiline
             maxLength={500}
           />
-          
+
           <TouchableOpacity
             onPress={sendMessage}
             disabled={loading || !input.trim()}
             className={`w-10 h-10 rounded-full items-center justify-center ${
-              loading || !input.trim() ? 'bg-gray-300' : 'bg-primary'
+              loading || !input.trim() ? "bg-gray-300" : "bg-primary"
             }`}
           >
             {loading ? (
@@ -143,7 +143,7 @@ const ChatScreen = () => {
           </TouchableOpacity>
         </View>
       </KeyboardAvoidingView>
-    </SafeAreaView>
+    </ScreenContainer>
   );
 };
 

--- a/homesync-india/src/screens/HomeScreen.tsx
+++ b/homesync-india/src/screens/HomeScreen.tsx
@@ -1,66 +1,60 @@
-import React from 'react';
-import { StyleSheet, View, TouchableOpacity, Image } from 'react-native';
-import { Text, Button, useTheme } from 'react-native-paper';
-import { SafeAreaView } from 'react-native-safe-area-context';
-import { useNavigation } from '@react-navigation/native';
+import React from "react";
+import { StyleSheet, View, TouchableOpacity, Image } from "react-native";
+import { Text, Button, useTheme } from "react-native-paper";
+import ScreenContainer from "../components/animations/ScreenContainer";
+import { useNavigation } from "@react-navigation/native";
 
 const HomeScreen: React.FC = () => {
   const theme = useTheme();
   const navigation = useNavigation<any>();
 
   const goToAdmin = () => {
-    navigation.navigate('Admin');
+    navigation.navigate("Admin");
   };
 
   const goToLogin = () => {
-    navigation.navigate('Login');
+    navigation.navigate("Login");
   };
-  
+
   return (
-    <SafeAreaView style={styles.container}>
+    <ScreenContainer style={styles.container}>
       <View style={styles.content}>
         <View style={styles.header}>
-          <Text variant="headlineLarge" style={styles.title}>HomeSync India</Text>
+          <Text variant="headlineLarge" style={styles.title}>
+            HomeSync India
+          </Text>
           <Text variant="bodyLarge" style={styles.subtitle}>
             Your complete household management solution
           </Text>
         </View>
-        
+
         <View style={styles.buttonContainer}>
-          <Button 
-            mode="contained" 
-            style={styles.button}
-            onPress={goToLogin}
-          >
+          <Button mode="contained" style={styles.button} onPress={goToLogin}>
             Sign In
           </Button>
-          
-          <Button 
-            mode="outlined" 
-            style={styles.button}
-            onPress={goToAdmin}
-          >
+
+          <Button mode="outlined" style={styles.button} onPress={goToAdmin}>
             Admin Dashboard
           </Button>
         </View>
       </View>
-    </SafeAreaView>
+    </ScreenContainer>
   );
 };
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#fff',
+    backgroundColor: "#fff",
   },
   content: {
     flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
+    justifyContent: "center",
+    alignItems: "center",
     padding: 20,
   },
   header: {
-    alignItems: 'center',
+    alignItems: "center",
     marginBottom: 60,
   },
   logo: {
@@ -69,18 +63,18 @@ const styles = StyleSheet.create({
     marginBottom: 20,
   },
   title: {
-    fontWeight: 'bold',
-    color: '#333',
+    fontWeight: "bold",
+    color: "#333",
     marginBottom: 10,
-    textAlign: 'center',
+    textAlign: "center",
   },
   subtitle: {
-    color: '#666',
-    textAlign: 'center',
+    color: "#666",
+    textAlign: "center",
     marginBottom: 10,
   },
   buttonContainer: {
-    width: '100%',
+    width: "100%",
     maxWidth: 300,
   },
   button: {

--- a/homesync-india/src/screens/auth/LoginScreen.tsx
+++ b/homesync-india/src/screens/auth/LoginScreen.tsx
@@ -1,42 +1,52 @@
-import React, { useState } from 'react';
-import { View, StyleSheet, TouchableOpacity } from 'react-native';
-import { Text, Card, Button, TextInput, useTheme, ActivityIndicator } from 'react-native-paper';
-import { SafeAreaView } from 'react-native-safe-area-context';
-import { useNavigation } from '@react-navigation/native';
-import { StackNavigationProp } from '@react-navigation/stack';
-import { authService } from '../../services/auth/AuthService';
-import { RootStackParamList } from '../../navigation/AppNavigator';
+import React, { useState } from "react";
+import { View, StyleSheet, TouchableOpacity } from "react-native";
+import {
+  Text,
+  Card,
+  Button,
+  TextInput,
+  useTheme,
+  ActivityIndicator,
+} from "react-native-paper";
+import ScreenContainer from "../../components/animations/ScreenContainer";
+import { useNavigation } from "@react-navigation/native";
+import { StackNavigationProp } from "@react-navigation/stack";
+import { authService } from "../../services/auth/AuthService";
+import { RootStackParamList } from "../../navigation/AppNavigator";
 
-type LoginScreenNavigationProp = StackNavigationProp<RootStackParamList, 'Login'>;
+type LoginScreenNavigationProp = StackNavigationProp<
+  RootStackParamList,
+  "Login"
+>;
 
 const LoginScreen = () => {
   const navigation = useNavigation<LoginScreenNavigationProp>();
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
   const handleLogin = async () => {
     if (!email || !password) {
-      setError('Email and password are required');
+      setError("Email and password are required");
       return;
     }
-    
+
     setError(null);
     setLoading(true);
-    
+
     try {
       const response = await authService.login(email, password);
-      
+
       if (response.error || !response.data) {
-        setError(response.error || 'Login failed');
+        setError(response.error || "Login failed");
         return;
       }
-      
+
       // Navigate to Home on successful login
-      navigation.replace('Home');
+      navigation.replace("Home");
     } catch (err) {
-      setError('An unexpected error occurred');
+      setError("An unexpected error occurred");
       console.error(err);
     } finally {
       setLoading(false);
@@ -46,13 +56,17 @@ const LoginScreen = () => {
   const theme = useTheme();
 
   return (
-    <SafeAreaView style={styles.container}>
+    <ScreenContainer style={styles.container}>
       <View style={styles.content}>
         <View style={styles.header}>
-          <Text variant="headlineMedium" style={styles.title}>HomeSync India</Text>
-          <Text variant="bodyMedium" style={styles.subtitle}>Welcome back! Sign in to your account</Text>
+          <Text variant="headlineMedium" style={styles.title}>
+            HomeSync India
+          </Text>
+          <Text variant="bodyMedium" style={styles.subtitle}>
+            Welcome back! Sign in to your account
+          </Text>
         </View>
-        
+
         <Card style={styles.card}>
           <Card.Content>
             {error && (
@@ -60,7 +74,7 @@ const LoginScreen = () => {
                 <Text style={{ color: theme.colors.error }}>{error}</Text>
               </View>
             )}
-            
+
             <TextInput
               label="Email"
               placeholder="Enter your email"
@@ -71,7 +85,7 @@ const LoginScreen = () => {
               mode="outlined"
               style={styles.input}
             />
-            
+
             <TextInput
               label="Password"
               placeholder="Enter your password"
@@ -81,7 +95,7 @@ const LoginScreen = () => {
               mode="outlined"
               style={styles.input}
             />
-            
+
             <Button
               mode="contained"
               onPress={handleLogin}
@@ -89,50 +103,56 @@ const LoginScreen = () => {
               style={styles.loginButton}
               labelStyle={styles.buttonText}
             >
-              {loading ? <ActivityIndicator color="white" /> : 'Sign In'}
+              {loading ? <ActivityIndicator color="white" /> : "Sign In"}
             </Button>
-            
-            <TouchableOpacity 
-              onPress={() => navigation.navigate('ForgotPassword')}
+
+            <TouchableOpacity
+              onPress={() => navigation.navigate("ForgotPassword")}
               style={styles.forgotPassword}
             >
-              <Text style={{ color: theme.colors.primary }}>Forgot Password?</Text>
+              <Text style={{ color: theme.colors.primary }}>
+                Forgot Password?
+              </Text>
             </TouchableOpacity>
           </Card.Content>
         </Card>
-        
+
         <View style={styles.footer}>
-          <Text variant="bodyMedium" style={styles.footerText}>Don't have an account? </Text>
-          <TouchableOpacity onPress={() => navigation.navigate('Register')}>
-            <Text style={{ color: theme.colors.primary, fontWeight: 'bold' }}>Sign Up</Text>
+          <Text variant="bodyMedium" style={styles.footerText}>
+            Don't have an account?{" "}
+          </Text>
+          <TouchableOpacity onPress={() => navigation.navigate("Register")}>
+            <Text style={{ color: theme.colors.primary, fontWeight: "bold" }}>
+              Sign Up
+            </Text>
           </TouchableOpacity>
         </View>
       </View>
-    </SafeAreaView>
+    </ScreenContainer>
   );
 };
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#f5f5f5',
+    backgroundColor: "#f5f5f5",
   },
   content: {
     flex: 1,
-    justifyContent: 'center',
+    justifyContent: "center",
     padding: 16,
   },
   header: {
-    alignItems: 'center',
+    alignItems: "center",
     marginBottom: 24,
   },
   title: {
-    fontWeight: 'bold',
+    fontWeight: "bold",
     marginBottom: 8,
   },
   subtitle: {
-    color: '#666',
-    textAlign: 'center',
+    color: "#666",
+    textAlign: "center",
   },
   card: {
     marginBottom: 24,
@@ -141,10 +161,10 @@ const styles = StyleSheet.create({
   errorContainer: {
     marginBottom: 16,
     padding: 12,
-    backgroundColor: '#FFEBEE',
+    backgroundColor: "#FFEBEE",
     borderRadius: 4,
     borderWidth: 1,
-    borderColor: '#FFCDD2',
+    borderColor: "#FFCDD2",
   },
   input: {
     marginBottom: 16,
@@ -155,18 +175,18 @@ const styles = StyleSheet.create({
   },
   buttonText: {
     fontSize: 16,
-    fontWeight: 'bold',
+    fontWeight: "bold",
   },
   forgotPassword: {
-    alignItems: 'center',
+    alignItems: "center",
     marginTop: 8,
   },
   footer: {
-    flexDirection: 'row',
-    justifyContent: 'center',
+    flexDirection: "row",
+    justifyContent: "center",
   },
   footerText: {
-    color: '#666',
+    color: "#666",
   },
 });
 

--- a/homesync-india/src/screens/auth/RegisterScreen.tsx
+++ b/homesync-india/src/screens/auth/RegisterScreen.tsx
@@ -1,50 +1,60 @@
-import React, { useState } from 'react';
-import { View, StyleSheet, TouchableOpacity, ScrollView } from 'react-native';
-import { Text, Card, Button, TextInput, useTheme, ActivityIndicator } from 'react-native-paper';
-import { SafeAreaView } from 'react-native-safe-area-context';
-import { useNavigation } from '@react-navigation/native';
-import { StackNavigationProp } from '@react-navigation/stack';
-import { authService } from '../../services/auth/AuthService';
-import { RootStackParamList } from '../../navigation/AppNavigator';
+import React, { useState } from "react";
+import { View, StyleSheet, TouchableOpacity, ScrollView } from "react-native";
+import {
+  Text,
+  Card,
+  Button,
+  TextInput,
+  useTheme,
+  ActivityIndicator,
+} from "react-native-paper";
+import ScreenContainer from "../../components/animations/ScreenContainer";
+import { useNavigation } from "@react-navigation/native";
+import { StackNavigationProp } from "@react-navigation/stack";
+import { authService } from "../../services/auth/AuthService";
+import { RootStackParamList } from "../../navigation/AppNavigator";
 
-type RegisterScreenNavigationProp = StackNavigationProp<RootStackParamList, 'Register'>;
+type RegisterScreenNavigationProp = StackNavigationProp<
+  RootStackParamList,
+  "Register"
+>;
 
 const RegisterScreen = () => {
   const navigation = useNavigation<RegisterScreenNavigationProp>();
-  const [name, setName] = useState('');
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-  const [confirmPassword, setConfirmPassword] = useState('');
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
   const handleRegister = async () => {
     // Validate inputs
     if (!name || !email || !password || !confirmPassword) {
-      setError('All fields are required');
+      setError("All fields are required");
       return;
     }
-    
+
     if (password !== confirmPassword) {
-      setError('Passwords do not match');
+      setError("Passwords do not match");
       return;
     }
-    
+
     setError(null);
     setLoading(true);
-    
+
     try {
       const response = await authService.register(name, email, password);
-      
+
       if (response.error || !response.data) {
-        setError(response.error || 'Registration failed');
+        setError(response.error || "Registration failed");
         return;
       }
-      
+
       // Navigate to Home on successful registration
-      navigation.replace('Home');
+      navigation.replace("Home");
     } catch (err) {
-      setError('An unexpected error occurred');
+      setError("An unexpected error occurred");
       console.error(err);
     } finally {
       setLoading(false);
@@ -54,14 +64,18 @@ const RegisterScreen = () => {
   const theme = useTheme();
 
   return (
-    <SafeAreaView style={styles.container}>
+    <ScreenContainer style={styles.container}>
       <ScrollView contentContainerStyle={styles.scrollContent}>
         <View style={styles.content}>
           <View style={styles.header}>
-            <Text variant="headlineMedium" style={styles.title}>HomeSync India</Text>
-            <Text variant="bodyMedium" style={styles.subtitle}>Create your account</Text>
+            <Text variant="headlineMedium" style={styles.title}>
+              HomeSync India
+            </Text>
+            <Text variant="bodyMedium" style={styles.subtitle}>
+              Create your account
+            </Text>
           </View>
-          
+
           <Card style={styles.card}>
             <Card.Content>
               {error && (
@@ -69,7 +83,7 @@ const RegisterScreen = () => {
                   <Text style={{ color: theme.colors.error }}>{error}</Text>
                 </View>
               )}
-              
+
               <TextInput
                 label="Full Name"
                 placeholder="Enter your full name"
@@ -79,7 +93,7 @@ const RegisterScreen = () => {
                 mode="outlined"
                 style={styles.input}
               />
-              
+
               <TextInput
                 label="Email"
                 placeholder="Enter your email"
@@ -90,7 +104,7 @@ const RegisterScreen = () => {
                 mode="outlined"
                 style={styles.input}
               />
-              
+
               <TextInput
                 label="Password"
                 placeholder="Create a password"
@@ -100,7 +114,7 @@ const RegisterScreen = () => {
                 mode="outlined"
                 style={styles.input}
               />
-              
+
               <TextInput
                 label="Confirm Password"
                 placeholder="Confirm your password"
@@ -110,7 +124,7 @@ const RegisterScreen = () => {
                 mode="outlined"
                 style={styles.input}
               />
-              
+
               <Button
                 mode="contained"
                 onPress={handleRegister}
@@ -118,47 +132,55 @@ const RegisterScreen = () => {
                 style={styles.registerButton}
                 labelStyle={styles.buttonText}
               >
-                {loading ? <ActivityIndicator color="white" /> : 'Create Account'}
+                {loading ? (
+                  <ActivityIndicator color="white" />
+                ) : (
+                  "Create Account"
+                )}
               </Button>
             </Card.Content>
           </Card>
-          
+
           <View style={styles.footer}>
-            <Text variant="bodyMedium" style={styles.footerText}>Already have an account? </Text>
-            <TouchableOpacity onPress={() => navigation.navigate('Login')}>
-              <Text style={{ color: theme.colors.primary, fontWeight: 'bold' }}>Sign In</Text>
+            <Text variant="bodyMedium" style={styles.footerText}>
+              Already have an account?{" "}
+            </Text>
+            <TouchableOpacity onPress={() => navigation.navigate("Login")}>
+              <Text style={{ color: theme.colors.primary, fontWeight: "bold" }}>
+                Sign In
+              </Text>
             </TouchableOpacity>
           </View>
         </View>
       </ScrollView>
-    </SafeAreaView>
+    </ScreenContainer>
   );
 };
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#f5f5f5',
+    backgroundColor: "#f5f5f5",
   },
   scrollContent: {
     flexGrow: 1,
   },
   content: {
     flex: 1,
-    justifyContent: 'center',
+    justifyContent: "center",
     padding: 16,
   },
   header: {
-    alignItems: 'center',
+    alignItems: "center",
     marginBottom: 24,
   },
   title: {
-    fontWeight: 'bold',
+    fontWeight: "bold",
     marginBottom: 8,
   },
   subtitle: {
-    color: '#666',
-    textAlign: 'center',
+    color: "#666",
+    textAlign: "center",
   },
   card: {
     marginBottom: 24,
@@ -167,10 +189,10 @@ const styles = StyleSheet.create({
   errorContainer: {
     marginBottom: 16,
     padding: 12,
-    backgroundColor: '#FFEBEE',
+    backgroundColor: "#FFEBEE",
     borderRadius: 4,
     borderWidth: 1,
-    borderColor: '#FFCDD2',
+    borderColor: "#FFCDD2",
   },
   input: {
     marginBottom: 16,
@@ -181,15 +203,15 @@ const styles = StyleSheet.create({
   },
   buttonText: {
     fontSize: 16,
-    fontWeight: 'bold',
+    fontWeight: "bold",
   },
   footer: {
-    flexDirection: 'row',
-    justifyContent: 'center',
+    flexDirection: "row",
+    justifyContent: "center",
     marginTop: 8,
   },
   footerText: {
-    color: '#666',
+    color: "#666",
   },
 });
 


### PR DESCRIPTION
## Summary
- create `FadeInView` and `ScreenContainer` components for reusable animations
- wrap key screens in `ScreenContainer` for a fade‑in effect
- format updated files

## Testing
- `npm install`
- `npx prettier -w src/screens/HomeScreen.tsx src/screens/auth/LoginScreen.tsx src/screens/AdminScreen.tsx src/screens/ChatScreen.tsx src/screens/auth/RegisterScreen.tsx src/components/animations/FadeInView.tsx src/components/animations/ScreenContainer.tsx`
- `npx tsc --noEmit` *(fails: Argument type 'string | undefined' is not assignable to parameter of type 'string')*

------
https://chatgpt.com/codex/tasks/task_e_686531321fc48322bb70e7a21e1ed231