### PR TITLE
Fix AdminScreen navigation types

### DIFF
--- a/homesync-india/src/screens/AdminScreen.tsx
+++ b/homesync-india/src/screens/AdminScreen.tsx
@@ -3,6 +3,9 @@ import { ScrollView, StyleSheet, View, TouchableOpacity, RefreshControl, Dimensi
 import { Text, useTheme, Card, IconButton, Button, ActivityIndicator } from 'react-native-paper';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
+import ScreenContainer from '../components/animations/ScreenContainer';
+import { StackNavigationProp } from '@react-navigation/stack';
+import { RootStackParamList } from '../navigation/AppNavigator';
 
 type Screen = {
   name: string;
@@ -16,6 +19,9 @@ type ModuleSection = {
 };
 
 const { width: screenWidth } = Dimensions.get('window');
+
+type AdminScreenNavigationProp =
+  StackNavigationProp<RootStackParamList, 'Admin'>;
 
 const AdminScreen: React.FC = () => {
   const theme = useTheme();


### PR DESCRIPTION
## Summary
- import ScreenContainer and navigation types in AdminScreen
- add typed navigation prop for Admin screen

## Testing
- `npx tsc -p tsconfig.json` *(fails: HomeScreen merge markers, missing expo tsconfig)*

------
https://chatgpt.com/codex/tasks/task_e_6865385feec483228a9cef1408974845